### PR TITLE
Add pytest tests and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest -ra

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -ra

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six==1.17.0
 tqdm==4.67.1
 tzdata==2025.2
 urllib3==2.4.0
+pytest==8.2.0

--- a/tests/test_fetch_validate.py
+++ b/tests/test_fetch_validate.py
@@ -1,0 +1,44 @@
+import lxml.etree as ET
+import pytest
+
+from pmcgrab.fetch import validate_xml
+from pmcgrab.constants import NoDTDFoundError
+
+SUPPORTED_DTD = "https://dtd.nlm.nih.gov/ncbi/pmc/articleset/nlm-articleset-2.0.dtd"
+
+SIMPLE_XML = f"""<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE pmc-articleset SYSTEM '{SUPPORTED_DTD}'>
+<pmc-articleset>
+  <article></article>
+</pmc-articleset>
+"""
+
+UNSUPPORTED_XML = """<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE something SYSTEM 'http://example.com/unsupported.dtd'>
+<something></something>
+"""
+
+NO_DOCTYPE_XML = "<root/>"
+
+class DummyDTD:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def validate(self, tree):
+        return False
+
+
+def test_validate_xml_with_supported_dtd_returns_false(monkeypatch):
+    monkeypatch.setattr(ET, "DTD", DummyDTD)
+    tree = ET.ElementTree(ET.fromstring(SIMPLE_XML.encode()))
+    assert validate_xml(tree) is False
+
+def test_validate_xml_unsupported_dtd_raises_error():
+    tree = ET.ElementTree(ET.fromstring(UNSUPPORTED_XML.encode()))
+    with pytest.raises(NoDTDFoundError):
+        validate_xml(tree)
+
+def test_validate_xml_missing_doctype_raises_error():
+    tree = ET.ElementTree(ET.fromstring(NO_DOCTYPE_XML.encode()))
+    with pytest.raises(NoDTDFoundError):
+        validate_xml(tree)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,57 @@
+import lxml.etree as ET
+import datetime
+from pmcgrab import parser
+from pmcgrab.model import TextSection, TextParagraph
+
+SAMPLE_XML = """<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE pmc-articleset SYSTEM 'https://dtd.nlm.nih.gov/ncbi/pmc/articleset/nlm-articleset-2.0.dtd'>
+<pmc-articleset>
+  <article>
+    <front>
+      <journal-meta>
+        <journal-id journal-id-type='pmc'>journal123</journal-id>
+        <journal-title>Test Journal</journal-title>
+        <issn pub-type='epub'>1234-5678</issn>
+        <publisher>
+          <publisher-name>Test Publisher</publisher-name>
+        </publisher>
+      </journal-meta>
+      <article-meta>
+        <article-id pub-id-type='pmcid'>PMC12345</article-id>
+        <title-group><article-title>Sample Article</article-title></title-group>
+        <pub-date pub-type='ppub'>
+          <year>2024</year><month>1</month><day>15</day>
+        </pub-date>
+        <volume>1</volume>
+        <issue>2</issue>
+        <permissions>
+          <copyright-statement>Copyright 2024</copyright-statement>
+          <license license-type='open-access'>
+            <license-p>License text</license-p>
+          </license>
+        </permissions>
+      </article-meta>
+    </front>
+    <abstract><p>Abstract text</p></abstract>
+    <body>
+      <sec><title>Intro</title><p>Body paragraph</p></sec>
+    </body>
+    <back>
+      <fn-group><fn id='fn1'><p>Footnote</p></fn></fn-group>
+    </back>
+  </article>
+</pmc-articleset>
+"""
+
+def fake_get_xml(*args, **kwargs):
+    return ET.ElementTree(ET.fromstring(SAMPLE_XML.encode()))
+
+def test_paper_dict_from_pmc(monkeypatch):
+    monkeypatch.setattr(parser, "get_xml", fake_get_xml)
+    d = parser.paper_dict_from_pmc(1, "test@example.com", validate=False)
+    assert d["Title"] == "Sample Article"
+    assert d["Journal Title"] == "Test Journal"
+    assert d["Published Date"]["ppub"] == datetime.date(2024, 1, 15)
+    assert d["Footnote"] == "Footnote"
+    assert isinstance(d["Body"][0], TextSection)
+    assert isinstance(d["Abstract"][0], TextParagraph)


### PR DESCRIPTION
## Summary
- add simple pytest config and requirements
- create GitHub Actions workflow running `pytest`
- add tests for `fetch.validate_xml()`
- add tests for `parser.paper_dict_from_pmc()`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685113d256fc832bbdcbe45c5b7b1727