### PR TITLE
Remove automatic logging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ process_in_batches_with_retry(
 
 Each article is written to `output_papers/PMC.json`.
 
+## Logging
+
+`pmcgrab` uses Python's built-in `logging` module. The library does not
+configure logging for you, so to see informational or debugging output
+you should set up logging in your application before calling `pmcgrab`:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)  # use DEBUG for more detail
+```
+
+Once configured, log messages from the `pmcgrab` logger will be emitted
+according to your chosen logging level.
+
 ## The AI-Ready Output Structure
 
 The output JSON is designed for easy parsing and direct ingestion into AI pipelines. It separates key metadata from the core content and, most importantly, structures the body of the paper into its constituent parts.

--- a/pmcgrab/constants.py
+++ b/pmcgrab/constants.py
@@ -3,7 +3,6 @@ import warnings
 import re
 import signal
 
-logging.basicConfig(level=logging.CRITICAL)
 logger = logging.getLogger(__name__)
 warnings.formatwarning = lambda msg, cat, *args, **kwargs: f"{cat.__name__}: {msg}\n\n"
 warnings.filterwarnings("ignore")


### PR DESCRIPTION
## Summary
- stop configuring logging in `pmcgrab.constants`
- mention how to enable logging in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685113b67d40832bb0716d5dd8479597